### PR TITLE
Fix: Turntable Size and Model Rotation

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -97,6 +97,7 @@ impl Reify for State {
                 state.turntable_angle = angle;
             })
             .pos([0.0, 0.035, 0.0])
+            .inner_radius(self.radius)
             .build(),
         )
         .child(

--- a/src/main.rs
+++ b/src/main.rs
@@ -97,30 +97,30 @@ impl Reify for State {
             })
             .pos([0.0, 0.035, 0.0])
             .inner_radius(self.radius)
-            .build(),
-        )
-        .child(
-            Bounds::new(|state: &mut State, bounds| {
-                let Some(model_info) = state.model_info.get_mut() else {
-                    return;
-                };
-
-                model_info.height_offset = bounds.size.y / 2.0;
-
-                let min_size = bounds.size.x.min(bounds.size.z);
-                model_info.scale = state.radius * 2.0 / min_size;
-            })
-            .scl([model_info.scale; 3])
             .build()
-            .maybe_child(model)
-            .maybe_child(model_error),
-        )
-        .child(
-            FileWatcher::new(self.model_path.clone(), |state: &mut State| {
-                println!("file is modified");
-                state.model_info.take();
-            })
-            .build(),
+            .child(
+                Bounds::new(|state: &mut State, bounds| {
+                    let Some(model_info) = state.model_info.get_mut() else {
+                        return;
+                    };
+
+                    model_info.height_offset = bounds.size.y / 2.0;
+
+                    let min_size = bounds.size.x.min(bounds.size.z);
+                    model_info.scale = state.radius * 2.0 / min_size;
+                })
+                .scl([model_info.scale; 3])
+                .build()
+                .maybe_child(model)
+                .maybe_child(model_error)
+            )
+            .child(
+                FileWatcher::new(self.model_path.clone(), |state: &mut State| {
+                    println!("file is modified");
+                    state.model_info.take();
+                })
+                .build()
+            )
         )
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -89,8 +89,7 @@ impl Reify for State {
         GrabRing::new(self.pos, |state: &mut State, pos| {
             state.pos = pos;
         })
-        .radius(self.radius)
-        .thickness(0.02)
+        .radius(self.radius + 0.04)
         .build()
         .child(
             Turntable::new(self.turntable_angle, |state: &mut State, angle| {


### PR DESCRIPTION
This PR resolves two major issues:
- The turntable was visually oversized and did not match the original design.
- Rotating the turntable did not rotate the 3D model.

### Details
Restores the correct turntable ring thickness and radius, matching the appearance from before the refactor.
Ensures the 3D model rotates with the turntable by making the model (via [Bounds](vscode-file://vscode-app/opt/visual-studio-code/resources/app/out/vs/code/electron-browser/workbench/workbench.html)) a child of the [Turntable](vscode-file://vscode-app/opt/visual-studio-code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) element, as in the original working version.
All improvements and API changes from the recent refactor (commit 4cd9d64) are preserved.
### Testing

- The turntable now appears as a thin ring, not a thick disk.
- Rotating the turntable rotates the 3D model as expected.
- No regressions or loss of refactor intent.

### Related Issues
Closes #4
Closes #5